### PR TITLE
Update build.sh - reduces size to 368 bytes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,5 @@
 nasm -f elf echo.asm
 ld -o echo echo.o -melf_i386
 rm echo.o
+strip echo
 echo "Done building, the file 'echo' is your executable"


### PR DESCRIPTION
Stripping the binary makes it still work, and vastly reduces size.

```
$ file echo
echo: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, stripped
$ ls -lah echo
-rwxr-xr-x 1 hack hack 368 Feb  2 08:00 echo
$ ./echo "lol"
lol
$ ./echo -n "lol"
lol$
```

There are some possible further size reductions that I need to play with later involving the ELF headers that might be in a followup PR if I can get them to work.
